### PR TITLE
Prevent Generate Entity from creating Nether

### DIFF
--- a/DRODLib/Character.cpp
+++ b/DRODLib/Character.cpp
@@ -2743,7 +2743,8 @@ void CCharacter::Process(
 				const UINT identity = ph;
 				if (room.IsValidColRow(px,py)) {
 					if (identity < CUSTOM_CHARACTER_FIRST &&
-						(room.GetMonsterAtSquare(px, py) != NULL ||
+						(identity == M_NEATHER ||
+						 room.GetMonsterAtSquare(px, py) != NULL ||
 							pGame->IsPlayerAt(px, py)))
 					STOP_COMMAND;
 


### PR DESCRIPTION
It's possible to set _MyScriptH to 4, and thus Generate Entity number four. But entity number four is the Nether. The Nether can only work in a handful of rooms, and never works if created via Generate Entity.

So if you try to generate the Nether, it should fail. This two line change makes this happen, by dropping out of Generate Entity if it attempts to create the Nether.

See: http://forum.caravelgames.com/viewtopic.php?TopicID=43247